### PR TITLE
Add Kafka proxy record encryption with Kroxylicious and Vault

### DIFF
--- a/kafka-workshop/Chart.yaml
+++ b/kafka-workshop/Chart.yaml
@@ -20,6 +20,12 @@ dependencies:
   - name: service-registry-operator
     version: 0.1.0
     repository: file://service-registry-operator
+  - name: proxy-operator
+    version: 0.1.0
+    repository: file://proxy-operator
+  - name: vault
+    version: 0.1.0
+    repository: file://vault
   - name: workshop
     version: 0.1.0
     repository: file://workshop

--- a/kafka-workshop/kafka-proxy/.helmignore
+++ b/kafka-workshop/kafka-proxy/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kafka-workshop/kafka-proxy/Chart.yaml
+++ b/kafka-workshop/kafka-proxy/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: kafka-proxy
+description: A Helm chart for Kroxylicious Kafka Proxy with record encryption
+type: application
+version: 0.1.0

--- a/kafka-workshop/kafka-proxy/templates/_helpers.tpl
+++ b/kafka-workshop/kafka-proxy/templates/_helpers.tpl
@@ -1,0 +1,60 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "kafka-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "kafka-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "kafka-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "kafka-proxy.labels" -}}
+helm.sh/chart: {{ include "kafka-proxy.chart" . }}
+{{ include "kafka-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "kafka-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "kafka-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Determine target namespace
+*/}}
+{{- define "kafka-proxy.namespace" -}}
+{{- if .Values.namespace }}
+{{- printf "%s" .Values.namespace }}
+{{- else }}
+{{- printf "%s" .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/kafka-workshop/kafka-proxy/templates/proxy-cr.yaml
+++ b/kafka-workshop/kafka-proxy/templates/proxy-cr.yaml
@@ -1,0 +1,7 @@
+---
+kind: KafkaProxy
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: {{ .Values.proxy.name }}
+  namespace: {{ include "kafka-proxy.namespace" . }}
+spec: {}

--- a/kafka-workshop/kafka-proxy/templates/proxy-filter.yaml
+++ b/kafka-workshop/kafka-proxy/templates/proxy-filter.yaml
@@ -1,0 +1,17 @@
+---
+kind: KafkaProtocolFilter
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: {{ .Values.filter.name }}
+  namespace: {{ include "kafka-proxy.namespace" . }}
+spec:
+  type: io.kroxylicious.filter.encryption.RecordEncryption
+  configTemplate:
+    kms: VaultKmsService
+    kmsConfig:
+      vaultToken:
+        password: {{ .Values.filter.vaultToken }}
+      vaultTransitEngineUrl: {{ .Values.filter.vaultTransitEngineUrl }}
+    selector: TemplateKekSelector
+    selectorConfig:
+      template: {{ .Values.filter.kekTemplate | quote }}

--- a/kafka-workshop/kafka-proxy/templates/proxy-ingress.yaml
+++ b/kafka-workshop/kafka-proxy/templates/proxy-ingress.yaml
@@ -1,0 +1,11 @@
+---
+kind: KafkaProxyIngress
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: {{ .Values.ingress.name }}
+  namespace: {{ include "kafka-proxy.namespace" . }}
+spec:
+  proxyRef:
+    name: {{ .Values.proxy.name }}
+  clusterIP:
+    protocol: {{ .Values.ingress.protocol }}

--- a/kafka-workshop/kafka-proxy/templates/proxy-kafka-service.yaml
+++ b/kafka-workshop/kafka-proxy/templates/proxy-kafka-service.yaml
@@ -1,0 +1,11 @@
+---
+kind: KafkaService
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: {{ .Values.kafkaService.name }}
+  namespace: {{ include "kafka-proxy.namespace" . }}
+spec:
+  bootstrapServers: {{ .Values.kafkaService.bootstrapServers }}
+  nodeIdRanges:
+    - start: {{ .Values.kafkaService.nodeIdRangeStart }}
+      end: {{ .Values.kafkaService.nodeIdRangeEnd }}

--- a/kafka-workshop/kafka-proxy/templates/proxy-virtual-cluster.yaml
+++ b/kafka-workshop/kafka-proxy/templates/proxy-virtual-cluster.yaml
@@ -1,0 +1,16 @@
+---
+kind: VirtualKafkaCluster
+apiVersion: kroxylicious.io/v1alpha1
+metadata:
+  name: {{ .Values.virtualCluster.name }}
+  namespace: {{ include "kafka-proxy.namespace" . }}
+spec:
+  proxyRef:
+    name: {{ .Values.proxy.name }}
+  targetKafkaServiceRef:
+    name: {{ .Values.kafkaService.name }}
+  filterRefs:
+    - name: {{ .Values.filter.name }}
+  ingresses:
+    - ingressRef:
+        name: {{ .Values.ingress.name }}

--- a/kafka-workshop/kafka-proxy/values.yaml
+++ b/kafka-workshop/kafka-proxy/values.yaml
@@ -1,0 +1,21 @@
+proxy:
+  name: simple
+
+ingress:
+  name: cluster-ip
+  protocol: TCP
+
+filter:
+  name: encryption
+  vaultToken: myroottoken
+  vaultTransitEngineUrl: http://vault.kms.svc.cluster.local:8200/v1/transit
+  kekTemplate: "KEK-$(topicName)"
+
+kafkaService:
+  name: my-cluster
+  bootstrapServers: kafka-kafka-bootstrap.kafka.svc:9092
+  nodeIdRangeStart: 0
+  nodeIdRangeEnd: 2
+
+virtualCluster:
+  name: my-cluster

--- a/kafka-workshop/proxy-operator/.helmignore
+++ b/kafka-workshop/proxy-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kafka-workshop/proxy-operator/Chart.yaml
+++ b/kafka-workshop/proxy-operator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: proxy-operator
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0

--- a/kafka-workshop/proxy-operator/templates/_helpers.tpl
+++ b/kafka-workshop/proxy-operator/templates/_helpers.tpl
@@ -1,0 +1,77 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "proxy-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "proxy-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "proxy-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "proxy-operator.labels" -}}
+helm.sh/chart: {{ include "proxy-operator.chart" . }}
+{{ include "proxy-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "proxy-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "proxy-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Determine target namespace
+*/}}
+{{- define "proxy-operator.namespace" -}}
+{{- if .Values.namespace }}
+{{- printf "%s" .Values.namespace}}
+{{- else }}
+{{- printf "%s" .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+ArgoCD Syncwave
+*/}}
+{{- define "proxy-operator.argocd-syncwave" -}}
+{{- if .Values.argocd }}
+{{- if and (.Values.argocd.operator.syncwave) (.Values.argocd.enabled) -}}
+argocd.argoproj.io/sync-wave: "{{ .Values.argocd.operator.syncwave }}"
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- end }}

--- a/kafka-workshop/proxy-operator/templates/proxy-operator-group.yaml
+++ b/kafka-workshop/proxy-operator/templates/proxy-operator-group.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: {{ include "proxy-operator.name" . }}
+  namespace: {{ include "proxy-operator.namespace" . }}
+  annotations:
+    {{- include "proxy-operator.argocd-syncwave" . | nindent 4 }}
+spec: {}

--- a/kafka-workshop/proxy-operator/templates/proxy-operator-namespace.yaml
+++ b/kafka-workshop/proxy-operator/templates/proxy-operator-namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "proxy-operator.namespace" . }}
+  labels:
+    app.kubernetes.io/name: amq-streams-proxy
+    app.kubernetes.io/component: operator
+  annotations:
+    {{- include "proxy-operator.argocd-syncwave" . | nindent 4 }}

--- a/kafka-workshop/proxy-operator/templates/proxy-operator-subscription.yaml
+++ b/kafka-workshop/proxy-operator/templates/proxy-operator-subscription.yaml
@@ -1,0 +1,25 @@
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: {{ include "proxy-operator.name" . }}
+  namespace: {{ include "proxy-operator.namespace" . }}
+  annotations:
+    {{- include "proxy-operator.argocd-syncwave" . | nindent 4 }}
+spec:
+  channel: {{ .Values.subscription.channel }}
+  installPlanApproval: {{ .Values.subscription.installPlanApproval }}
+  name: {{ .Values.subscription.name }}
+  source: {{ .Values.subscription.source }}
+  sourceNamespace: {{ .Values.subscription.sourceNamespace }}
+  {{- if .Values.subscription.config }}
+  config:
+    {{- with .Values.subscription.config.resources }}
+    resources:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.subscription.config.env }}
+    env:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+  {{- end }}

--- a/kafka-workshop/proxy-operator/values.yaml
+++ b/kafka-workshop/proxy-operator/values.yaml
@@ -1,0 +1,25 @@
+nameOverride: "proxy-operator"
+fullnameOverride: ""
+
+namespace: amq-streams-proxy
+
+subscription:
+  channel: stable
+  installPlanApproval: Automatic
+  name: amq-streams-proxy
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+    resources:
+      requests:
+        memory: 1Gi
+      limits:
+        memory: 1Gi
+    env:
+      - name: JAVA_TOOL_OPTIONS
+        value: "-Xmx512m"
+
+argocd:
+  enabled: true
+  operator:
+    syncwave: "-2"

--- a/kafka-workshop/service-registry/service-registry/values.yaml
+++ b/kafka-workshop/service-registry/service-registry/values.yaml
@@ -24,7 +24,7 @@ app:
   livenessProbe:
     httpGet:
       path: /health/live
-      port: 8080
+      port: 9000
       scheme: HTTP
     initialDelaySeconds: 60
     timeoutSeconds: 3
@@ -35,7 +35,7 @@ app:
   readinessProbe:
     httpGet:
       path: /health/ready
-      port: 8080
+      port: 9000
       scheme: HTTP
     initialDelaySeconds: 60
     timeoutSeconds: 3

--- a/kafka-workshop/values.yaml
+++ b/kafka-workshop/values.yaml
@@ -15,7 +15,7 @@ workshop:
   proxy:
     source:
       repoUrl: https://github.com/streams-kafka-workshop/helm.git
-      targetRevision: proxy
+      targetRevision: main
   gitops:
     source:
       repoUrl: https://github.com/streams-kafka-workshop/helm.git

--- a/kafka-workshop/values.yaml
+++ b/kafka-workshop/values.yaml
@@ -1,4 +1,21 @@
+proxy-operator:
+  argocd:
+    operator:
+      syncwave: "-2"
+
+vault:
+  vault:
+    global:
+      namespace: kms
+  argocd:
+    vault:
+      syncwave: "-1"
+
 workshop:
+  proxy:
+    source:
+      repoUrl: https://github.com/streams-kafka-workshop/helm.git
+      targetRevision: main
   gitops:
     source:
       repoUrl: https://github.com/streams-kafka-workshop/helm.git
@@ -27,7 +44,7 @@ workshop:
     namespace:
       syncwave: "-1"
     gitops:
-      syncwave: "-1" 
+      syncwave: "-1"
     amqstreams:
       syncwave: "0"
     keycloak:
@@ -37,6 +54,8 @@ workshop:
     service_registry:
       syncwave: "1"
     globex_cdc:
+      syncwave: "2"
+    proxy:
       syncwave: "2"
 
 devspaces:

--- a/kafka-workshop/values.yaml
+++ b/kafka-workshop/values.yaml
@@ -15,7 +15,7 @@ workshop:
   proxy:
     source:
       repoUrl: https://github.com/streams-kafka-workshop/helm.git
-      targetRevision: main
+      targetRevision: proxy
   gitops:
     source:
       repoUrl: https://github.com/streams-kafka-workshop/helm.git

--- a/kafka-workshop/vault/.helmignore
+++ b/kafka-workshop/vault/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kafka-workshop/vault/Chart.yaml
+++ b/kafka-workshop/vault/Chart.yaml
@@ -4,7 +4,3 @@ description: A Helm chart for HashiCorp Vault with Transit engine for Kafka reco
 type: application
 version: 0.1.0
 
-dependencies:
-  - name: vault
-    version: 0.32.0
-    repository: https://helm.releases.hashicorp.com

--- a/kafka-workshop/vault/Chart.yaml
+++ b/kafka-workshop/vault/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v2
+name: vault
+description: A Helm chart for HashiCorp Vault with Transit engine for Kafka record encryption
+type: application
+version: 0.1.0
+
+dependencies:
+  - name: vault
+    version: 0.32.0
+    repository: https://helm.releases.hashicorp.com

--- a/kafka-workshop/vault/templates/_helpers.tpl
+++ b/kafka-workshop/vault/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "vault-wrapper.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Determine target namespace
+*/}}
+{{- define "vault-wrapper.namespace" -}}
+{{- if .Values.namespace }}
+{{- printf "%s" .Values.namespace }}
+{{- else }}
+{{- printf "%s" .Release.Namespace }}
+{{- end }}
+{{- end }}
+
+{{/*
+ArgoCD Syncwave
+*/}}
+{{- define "vault-wrapper.argocd-syncwave" -}}
+{{- if .Values.argocd }}
+{{- if and (.Values.argocd.vault) (.Values.argocd.vault.syncwave) (.Values.argocd.enabled) -}}
+argocd.argoproj.io/sync-wave: "{{ .Values.argocd.vault.syncwave }}"
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- end }}

--- a/kafka-workshop/vault/templates/vault-argocd-app.yaml
+++ b/kafka-workshop/vault/templates/vault-argocd-app.yaml
@@ -1,0 +1,49 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: vault
+  namespace: {{ .Values.vaultApp.applicationNamespace }}
+  annotations:
+    {{- include "vault-wrapper.argocd-syncwave" . | nindent 4 }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  destination:
+    name: ""
+    namespace: {{ include "vault-wrapper.namespace" . }}
+    server: 'https://kubernetes.default.svc'
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 10
+    syncOptions:
+      - RespectIgnoreDifferences=true
+  source:
+    chart: vault
+    repoURL: {{ .Values.vaultApp.repoURL }}
+    targetRevision: {{ .Values.vaultApp.chartVersion }}
+    helm:
+      valuesObject:
+        global:
+          openshift: {{ .Values.vault.global.openshift }}
+        server:
+          dev:
+            enabled: {{ .Values.vault.server.dev.enabled }}
+            devRootToken: {{ .Values.vault.server.dev.devRootToken }}
+          extraEnvironmentVars:
+            SKIP_SETCAP: "true"
+          image:
+            repository: {{ .Values.vault.server.image.repository }}
+        injector:
+          image:
+            repository: {{ .Values.vault.injector.image.repository }}
+          agentImage:
+            repository: {{ .Values.vault.injector.agentImage.repository }}

--- a/kafka-workshop/vault/templates/vault-namespace.yaml
+++ b/kafka-workshop/vault/templates/vault-namespace.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "vault-wrapper.namespace" . }}
+  labels:
+    app.kubernetes.io/name: vault
+    app.kubernetes.io/component: kms
+  annotations:
+    {{- include "vault-wrapper.argocd-syncwave" . | nindent 4 }}

--- a/kafka-workshop/vault/templates/vault-scc.yaml
+++ b/kafka-workshop/vault/templates/vault-scc.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.openshift.enabled }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-scc-anyuid
+  annotations:
+    {{- include "vault-wrapper.argocd-syncwave" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: vault
+    namespace: {{ include "vault-wrapper.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: vault-agent-injector-scc-anyuid
+  annotations:
+    {{- include "vault-wrapper.argocd-syncwave" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: vault-agent-injector
+    namespace: {{ include "vault-wrapper.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/kafka-workshop/vault/templates/vault-transit-job.yaml
+++ b/kafka-workshop/vault/templates/vault-transit-job.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: vault-transit-setup
+  namespace: {{ include "vault-wrapper.namespace" . }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "0"
+    argocd.argoproj.io/hook: PostSync
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      initContainers:
+        - name: wait-for-vault
+          image: {{ .Values.vaultImage }}
+          env:
+            - name: VAULT_ADDR
+              value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until vault status > /dev/null 2>&1; do
+                echo "Waiting for Vault to be ready..."
+                sleep 5
+              done
+              echo "Vault is ready"
+      containers:
+        - name: setup-transit
+          image: {{ .Values.vaultImage }}
+          env:
+            - name: VAULT_ADDR
+              value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
+            - name: VAULT_TOKEN
+              value: "myroottoken"
+          command:
+            - /bin/sh
+            - -c
+            - |
+              echo "Enabling Transit secrets engine..."
+              vault secrets enable transit 2>/dev/null || echo "Transit engine already enabled"
+
+              {{- range .Values.topics }}
+              echo "Creating KEK for topic: {{ . }}"
+              vault write -f transit/keys/KEK-{{ . }}
+              {{- end }}
+
+              echo "Vault Transit setup complete"

--- a/kafka-workshop/vault/templates/vault-transit-job.yaml
+++ b/kafka-workshop/vault/templates/vault-transit-job.yaml
@@ -1,50 +1,54 @@
 ---
 apiVersion: batch/v1
-kind: Job
+kind: CronJob
 metadata:
   name: vault-transit-setup
   namespace: {{ include "vault-wrapper.namespace" . }}
   annotations:
-    argocd.argoproj.io/sync-wave: "0"
-    argocd.argoproj.io/hook: PostSync
+    {{- include "vault-wrapper.argocd-syncwave" . | nindent 4 }}
 spec:
-  backoffLimit: 10
-  template:
+  schedule: "*/5 * * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 1
+  jobTemplate:
     spec:
-      restartPolicy: OnFailure
-      initContainers:
-        - name: wait-for-vault
-          image: {{ .Values.vaultImage }}
-          env:
-            - name: VAULT_ADDR
-              value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
-          command:
-            - /bin/sh
-            - -c
-            - |
-              until vault status > /dev/null 2>&1; do
-                echo "Waiting for Vault to be ready..."
-                sleep 5
-              done
-              echo "Vault is ready"
-      containers:
-        - name: setup-transit
-          image: {{ .Values.vaultImage }}
-          env:
-            - name: VAULT_ADDR
-              value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
-            - name: VAULT_TOKEN
-              value: "myroottoken"
-          command:
-            - /bin/sh
-            - -c
-            - |
-              echo "Enabling Transit secrets engine..."
-              vault secrets enable transit 2>/dev/null || echo "Transit engine already enabled"
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: OnFailure
+          initContainers:
+            - name: wait-for-vault
+              image: {{ .Values.vaultImage }}
+              env:
+                - name: VAULT_ADDR
+                  value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  until vault status > /dev/null 2>&1; do
+                    echo "Waiting for Vault to be ready..."
+                    sleep 5
+                  done
+                  echo "Vault is ready"
+          containers:
+            - name: setup-transit
+              image: {{ .Values.vaultImage }}
+              env:
+                - name: VAULT_ADDR
+                  value: "http://vault.{{ include "vault-wrapper.namespace" . }}.svc.cluster.local:8200"
+                - name: VAULT_TOKEN
+                  value: "myroottoken"
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  echo "Enabling Transit secrets engine..."
+                  vault secrets enable transit 2>/dev/null || echo "Transit engine already enabled"
 
-              {{- range .Values.topics }}
-              echo "Creating KEK for topic: {{ . }}"
-              vault write -f transit/keys/KEK-{{ . }}
-              {{- end }}
+                  {{- range .Values.topics }}
+                  echo "Creating KEK for topic: {{ . }}"
+                  vault write -f transit/keys/KEK-{{ . }}
+                  {{- end }}
 
-              echo "Vault Transit setup complete"
+                  echo "Vault Transit setup complete"

--- a/kafka-workshop/vault/values.yaml
+++ b/kafka-workshop/vault/values.yaml
@@ -1,0 +1,35 @@
+nameOverride: "vault"
+fullnameOverride: ""
+
+namespace: kms
+
+vault:
+  global:
+    openshift: true
+    namespace: kms
+  server:
+    dev:
+      enabled: true
+      devRootToken: myroottoken
+    extraEnvironmentVars:
+      SKIP_SETCAP: "true"
+    image:
+      repository: docker.io/hashicorp/vault
+  injector:
+    image:
+      repository: docker.io/hashicorp/vault-k8s
+    agentImage:
+      repository: docker.io/hashicorp/vault
+
+openshift:
+  enabled: true
+
+topics:
+  - trades
+
+vaultImage: docker.io/hashicorp/vault:1.19.0
+
+argocd:
+  enabled: true
+  vault:
+    syncwave: "-1"

--- a/kafka-workshop/vault/values.yaml
+++ b/kafka-workshop/vault/values.yaml
@@ -30,7 +30,7 @@ openshift:
   enabled: true
 
 topics:
-  - trades
+  - customer-payments
 
 vaultImage: docker.io/hashicorp/vault:1.19.0
 

--- a/kafka-workshop/vault/values.yaml
+++ b/kafka-workshop/vault/values.yaml
@@ -3,6 +3,11 @@ fullnameOverride: ""
 
 namespace: kms
 
+vaultApp:
+  chartVersion: "0.32.0"
+  repoURL: https://helm.releases.hashicorp.com
+  applicationNamespace: openshift-gitops
+
 vault:
   global:
     openshift: true

--- a/kafka-workshop/workshop/templates/_helpers.tpl
+++ b/kafka-workshop/workshop/templates/_helpers.tpl
@@ -165,3 +165,18 @@ argocd.argoproj.io/sync-wave: "{{ .Values.argocd.globex_cdc.syncwave }}"
 {{- "{}" }}
 {{- end }}
 {{- end }}
+
+{{/*
+ArgoCD Syncwave
+*/}}
+{{- define "workshop.proxy.argocd-syncwave" -}}
+{{- if .Values.argocd }}
+{{- if and (.Values.argocd.proxy) (.Values.argocd.proxy.syncwave) (.Values.argocd.enabled) -}}
+argocd.argoproj.io/sync-wave: "{{ .Values.argocd.proxy.syncwave }}"
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- else }}
+{{- "{}" }}
+{{- end }}
+{{- end }}

--- a/kafka-workshop/workshop/templates/proxy.yaml
+++ b/kafka-workshop/workshop/templates/proxy.yaml
@@ -1,0 +1,40 @@
+{{- range untilStep 0 (.Values.loop.count | int64 | int) 1 }}
+{{ $loop := printf "%s%s" $.Values.loop.prefix ((add . 1) | toString) }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ $.Values.proxy.applicationName }}-{{ $loop }}
+  namespace: {{ $.Values.proxy.applicationNamespace }}-{{ $loop }}
+  annotations:
+    {{- include "workshop.proxy.argocd-syncwave" $ | nindent 4 }}
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  destination:
+    name: ""
+    namespace: {{ $.Values.proxy.destinationNamespace }}-{{ $loop }}
+    server: 'https://kubernetes.default.svc'
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    retry:
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m0s
+      limit: 10
+    syncOptions:
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+  source:
+    repoURL: {{ $.Values.proxy.source.repoUrl }}
+    targetRevision: {{ $.Values.proxy.source.targetRevision }}
+    path: {{ $.Values.proxy.source.path }}
+    helm:
+      valuesObject:
+        kafkaService:
+          bootstrapServers: kafka-kafka-bootstrap.{{ $.Values.amqstreams.destinationNamespace }}-{{ $loop }}.svc:9092
+{{- end }}

--- a/kafka-workshop/workshop/values.yaml
+++ b/kafka-workshop/workshop/values.yaml
@@ -77,11 +77,21 @@ globex_cdc:
     targetRevision:
     path: kafka-workshop/globex-cdc
 
+proxy:
+  applicationName: kafka-proxy
+  applicationNamespace: gitops
+  destinationNamespace: proxy
+  source:
+    repoUrl:
+    targetRevision:
+    path: kafka-workshop/kafka-proxy
+
 namespaces:
   - name: kafka
   - name: globex
   - name: service-registry
   - name: globex-cdc
+  - name: proxy
 
 argocd:
   enabled: true
@@ -98,4 +108,6 @@ argocd:
   service_registry:
     syncwave: "1"
   globex_cdc:
+    syncwave: "2"
+  proxy:
     syncwave: "2"


### PR DESCRIPTION
## Summary
- Add proxy-operator subchart to install Kroxylicious operator via OLM
- Add vault subchart to deploy HashiCorp Vault (dev mode) with Transit engine for KEK management
- Add kafka-proxy subchart with per-user Kroxylicious CRDs (KafkaProxy, KafkaProxyIngress, KafkaProtocolFilter, KafkaService, VirtualKafkaCluster)
- Deploy vault via ArgoCD Application instead of nested subchart dependency
- CronJob runs every 5 minutes to idempotently restore Transit engine and KEKs after vault restarts
- Default topic: customer-payments

## Test plan
- [x] Verified on fresh OpenShift cluster with 3 users
- [x] All KafkaProxy and VirtualKafkaCluster CRDs report Ready/Accepted
- [x] Produced via proxy, consumed directly from Kafka - data is encrypted
- [x] Consumed via proxy - data is decrypted
- [x] Restarted vault pod - CronJob restored transit keys within 5 minutes
- [x] Verified RBAC isolation: users can only access their own namespaces
- [x] All targetRevision values set to main